### PR TITLE
fixed a bug where Wire.begin() cannot be called within another class constructor

### DIFF
--- a/MacRocketry_BMP_180.cpp
+++ b/MacRocketry_BMP_180.cpp
@@ -28,6 +28,8 @@ bool MacRocketry_BMP_180::getConnectBMP(void){ return connectBMP; }
 float MacRocketry_BMP_180::getTemperature(void){ return temperature; }
 float MacRocketry_BMP_180::getPressure(void){ return pressure; }
 float MacRocketry_BMP_180::getAltitude(void){ return altitude; }
+uint32_t MacRocketry_BMP_180::getTime(void){ return time; }
+
 void MacRocketry_BMP_180::setSeaLevel_hPa(int p){ seaPressure = p; }
 void MacRocketry_BMP_180::setSeaLevel_kPa(int p){ seaPressure = p * 10; }
 void MacRocketry_BMP_180::setOversampling(char oversampling){ oss = oversampling; }
@@ -95,52 +97,13 @@ bool MacRocketry_BMP_180::begin(){
 
 //read BMP data state machine --------------------
 bool MacRocketry_BMP_180::readData(){
-  
-  #ifdef BMP180_NO_DELAY_READ //non blocking readData(), but must call twice
-  switch (state) {
-    case BMP_Init:
-      //first temperature reading
-      waitTimer = (unsigned long)startTemperature();
-      delay(waitTimer);
-      readTemperature();
-
-      //switch to looped state
-      waitTimer = millis() + (unsigned long)startPressure();
-      state = BMP_ReadPressure_StartTemperature;
-      break;
-      
-    case BMP_ReadPressure_StartTemperature:
-      if (waitTimer < millis()){
-        readPressure();
-        waitTimer = millis() + (unsigned long)startTemperature();
-        altitude = calcAltitude(pressure, seaPressure);
-        state = BMP_ReadTemperature_StartPressure;
-        return true;
-      }
-      break;
-      
-    case BMP_ReadTemperature_StartPressure:
-      if (waitTimer < millis()){
-        readTemperature();
-        waitTimer = millis() + (unsigned long)startPressure();
-        state = BMP_ReadPressure_StartTemperature;
-      }
-      break;
-      
-    default:
-      state = BMP_Init;
-      break;
-  }
-  return false; //if no new data
-  
-  #else
   delay(startTemperature());  //delay_block for BMP
   readTemperature();          //read temperature
   delay(startPressure());     //delay_block for BMP
   readPressure();             //read pressure
+  time = millis();            //set time right away
   altitude = calcAltitude(pressure, seaPressure);
   return true;
-  #endif
 }
 
 //functions for reading and writing I2C data from BMP --------------------

--- a/MacRocketry_BMP_180.cpp
+++ b/MacRocketry_BMP_180.cpp
@@ -10,10 +10,17 @@ This library is rewritten to suit the need and design for McMaster Rocketry Team
 
 //constructor --------------------
 MacRocketry_BMP_180::MacRocketry_BMP_180(void){ //constructor
+  #ifdef BMP180_NO_DELAY_READ
   state = BMP_Init;
+  #endif
+  
   oss = 0;                  //default oversampling
   setSeaLevel_hPa(1013.25); //default sea level
-  connectBMP = begin();
+  
+  //connectBMP = begin(); //there is a bug where Wire.begin() cannot be called within a class contructor
+  //therefore, we have to call MacRocketry_BMP_180::begin() inside setup() function
+  //so this line above is commented out, and connectBMP is evaluated inside MacRocketry_BMP_180::begin() instead
+
 }
 
 //getters and settes --------------------
@@ -27,6 +34,10 @@ void MacRocketry_BMP_180::setOversampling(char oversampling){ oss = oversampling
 
 //initialize BMP and calibration --------------------
 bool MacRocketry_BMP_180::begin(){
+  //https://github.com/esp8266/Arduino/issues/3570
+  //there is a bug where Wire.begin() cannot be called within a class contructor
+  //therefore, we have to call MacRocketry_BMP_180::begin() inside setup()
+  
   Wire.begin(); //start up the Arduino's "wire" (I2C) library
 
   //retrieve calibration data stored from device
@@ -74,14 +85,18 @@ bool MacRocketry_BMP_180::begin(){
     p1 = 1.0 - 7357.0 * pow(2,-20);
     p2 = 3038.0 * 100.0 * pow(2,-36);
     
-    return(1); //success!
+    connectBMP = true; //success!
+  } else {
+    connectBMP = false; //error reading calibration data; bad component or connection
   }
-  else return(0); //error reading calibration data; bad component or connection
+  return connectBMP;
 }
 
 
 //read BMP data state machine --------------------
 bool MacRocketry_BMP_180::readData(){
+  
+  #ifdef BMP180_NO_DELAY_READ //non blocking readData(), but must call twice
   switch (state) {
     case BMP_Init:
       //first temperature reading
@@ -117,6 +132,15 @@ bool MacRocketry_BMP_180::readData(){
       break;
   }
   return false; //if no new data
+  
+  #else
+  delay(startTemperature());  //delay_block for BMP
+  readTemperature();          //read temperature
+  delay(startPressure());     //delay_block for BMP
+  readPressure();             //read pressure
+  altitude = calcAltitude(pressure, seaPressure);
+  return true;
+  #endif
 }
 
 //functions for reading and writing I2C data from BMP --------------------
@@ -288,7 +312,6 @@ float MacRocketry_BMP_180::calcAltitude(float P, float P0){
   //return altitude (meters) above baseline
   return(44330.0 * (1 - pow(P/P0, 1/5.255)));
 }
-
 
 bool MacRocketry_BMP_180::getError(void){
   //if any library command fails, you can retrieve an extended

--- a/MacRocketry_BMP_180.h
+++ b/MacRocketry_BMP_180.h
@@ -20,11 +20,16 @@ This library is rewritten to suit the need and design for McMaster Rocketry Team
 #define BMP180_COMMAND_PRESSURE_2 0xB4
 #define BMP180_COMMAND_PRESSURE_3 0xF4
 
+//currently will wait for BMP IO to read data
+//uncomment line below to not block arduino from IO
+//#define BMP180_NO_DELAY_READ
+#ifdef BMP180_NO_DELAY_READ
 enum BMPState {
   BMP_Init,
   BMP_ReadPressure_StartTemperature,
   BMP_ReadTemperature_StartPressure
 };
+#endif
 
 class MacRocketry_BMP_180
 {
@@ -73,7 +78,10 @@ class MacRocketry_BMP_180
     char oss; //oversampling setting
     
     unsigned long waitTimer;
+    
+    #ifdef BMP180_NO_DELAY_READ
     BMPState state;
+    #endif
     
     float temperature, pressure, seaPressure, altitude;
 };

--- a/MacRocketry_BMP_180.h
+++ b/MacRocketry_BMP_180.h
@@ -20,17 +20,6 @@ This library is rewritten to suit the need and design for McMaster Rocketry Team
 #define BMP180_COMMAND_PRESSURE_2 0xB4
 #define BMP180_COMMAND_PRESSURE_3 0xF4
 
-//currently will wait for BMP IO to read data
-//uncomment line below to not block arduino from IO
-//#define BMP180_NO_DELAY_READ
-#ifdef BMP180_NO_DELAY_READ
-enum BMPState {
-  BMP_Init,
-  BMP_ReadPressure_StartTemperature,
-  BMP_ReadTemperature_StartPressure
-};
-#endif
-
 class MacRocketry_BMP_180
 {
   public:
@@ -53,6 +42,7 @@ class MacRocketry_BMP_180
     float getTemperature(void);
     float getPressure(void);
     float getAltitude(void);
+    uint32_t getTime(void);
     
     void setSeaLevel_hPa(int p);
     void setSeaLevel_kPa(int p);
@@ -77,13 +67,8 @@ class MacRocketry_BMP_180
     bool connectBMP;
     char oss; //oversampling setting
     
-    unsigned long waitTimer;
-    
-    #ifdef BMP180_NO_DELAY_READ
-    BMPState state;
-    #endif
-    
     float temperature, pressure, seaPressure, altitude;
+    uint32_t time;
 };
 
 

--- a/examples/BMP_180_include_example/BMP_180_include_example.ino
+++ b/examples/BMP_180_include_example/BMP_180_include_example.ino
@@ -1,9 +1,12 @@
-#include <MacRocketry_BMP_180.h>   //include header file
+#include <MacRocketry_GPS_Shield.h> //include GPS
+#include <MacRocketry_BMP_180.h>    //include BMP
 
 MacRocketry_BMP_180 bmp;
+MacRocketry_GPS_Shield gps;
 
 void setup() {
   Serial.begin(9600);
+  bmp.begin(); //must call this in setup
 }
 
 void loop() {


### PR DESCRIPTION
The library is now functional. We can use this library instead of the Adafruit library for simpler function calls and access